### PR TITLE
Fix bounds check in EAP code

### DIFF
--- a/progs.gpl/pppd.alpha/eap.c
+++ b/progs.gpl/pppd.alpha/eap.c
@@ -1427,7 +1427,7 @@ int len;
 		}
 
 		/* Not so likely to happen. */
-		if (vallen >= len + sizeof (rhostname)) {
+		if (len - vallen >= sizeof (rhostname)) {
 			dbglog("EAP: trimming really long peer name down");
 			BCOPY(inp + vallen, rhostname, sizeof (rhostname) - 1);
 			rhostname[sizeof (rhostname) - 1] = '\0';
@@ -1853,7 +1853,7 @@ int len;
 		}
 
 		/* Not so likely to happen. */
-		if (vallen >= len + sizeof (rhostname)) {
+		if (len - vallen >= sizeof (rhostname)) {
 			dbglog("EAP: trimming really long peer name down");
 			BCOPY(inp + vallen, rhostname, sizeof (rhostname) - 1);
 			rhostname[sizeof (rhostname) - 1] = '\0';


### PR DESCRIPTION
Given that we have just checked vallen < len, it can never be the case
that vallen >= len + sizeof(rhostname).  This fixes the check so we
actually avoid overflowing the rhostname array.